### PR TITLE
Implement TopAppBar

### DIFF
--- a/app/src/main/java/com/example/valorantandroid/ValorantActivity.kt
+++ b/app/src/main/java/com/example/valorantandroid/ValorantActivity.kt
@@ -4,8 +4,16 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.example.valorantandroid.theme.ValorantAndroidTheme
 import com.example.valorantandroid.ui.core.ValorantApp
@@ -26,4 +34,29 @@ class ValorantActivity : ComponentActivity() {
             }
         }
     }
+}
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ValorantTopAppBar(
+    appBarTitle: String,
+    canNavigateUp: Boolean,
+    navigateUp: () -> Unit
+) {
+    TopAppBar(
+        title = {
+            Text(text = appBarTitle)
+        },
+        navigationIcon = {
+            if (canNavigateUp) {
+                IconButton(onClick = { navigateUp() }) {
+                    Icon(
+                        imageVector = Icons.Filled.ArrowBack,
+                        contentDescription = "Localized description"
+                    )
+                }
+            }
+        }
+    )
 }

--- a/app/src/main/java/com/example/valorantandroid/feature/agent/AgentDetailsScreen.kt
+++ b/app/src/main/java/com/example/valorantandroid/feature/agent/AgentDetailsScreen.kt
@@ -2,6 +2,7 @@ package com.example.valorantandroid.feature.agent
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -19,7 +20,7 @@ fun AgentDetailsScreen(
 ) {
     when (agentDetailsUiState) {
         is AgentDetailsUiState.Success -> AgentDetails(agent = agentDetailsUiState.agent)
-        is AgentDetailsUiState.Loading -> Text(text = "Loading")
+        is AgentDetailsUiState.Loading -> Text(text = "Loading", modifier = modifier.fillMaxSize())
         is AgentDetailsUiState.Error -> Text(text = "Error")
     }
 }
@@ -32,7 +33,7 @@ fun AgentDetails(
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
-        modifier = modifier
+        modifier = modifier.fillMaxSize()
     ) {
         Text(
             text = agent.displayName,

--- a/app/src/main/java/com/example/valorantandroid/feature/agent/AgentsScreen.kt
+++ b/app/src/main/java/com/example/valorantandroid/feature/agent/AgentsScreen.kt
@@ -1,6 +1,7 @@
 package com.example.valorantandroid.feature.agent
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -21,28 +22,44 @@ import com.example.valorantandroid.data.AgentsNetworkModel.Agent
 @Composable
 fun AgentsScreen(
     agentsUiState: AgentsUiState,
-    onAgentClicked: (uuid: String) -> Unit,
+    onAgentClicked: (uuid: String, name: String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     when (agentsUiState) {
-        is AgentsUiState.IsLoading -> Text(text = "Loading")
-        is AgentsUiState.Success -> AgentsList(agents = agentsUiState.agents, onAgentClicked)
-        is AgentsUiState.IsError -> Text(text = agentsUiState.message)
+        is AgentsUiState.IsLoading -> Text(
+            text = "Loading",
+            modifier = modifier
+                .fillMaxSize()
+        )
+        is AgentsUiState.Success -> AgentsList(
+            agents = agentsUiState.agents,
+            onAgentClicked = onAgentClicked,
+            modifier = modifier
+                .fillMaxSize()
+        )
+        is AgentsUiState.IsError -> Text(
+            text = agentsUiState.message,
+            modifier
+                .fillMaxSize()
+        )
     }
 }
 
 @Composable
 fun AgentsList(
     agents: List<Agent>,
-    onAgentClicked: (uuid: String) -> Unit,
+    onAgentClicked: (uuid: String, name: String) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    LazyVerticalGrid(columns = GridCells.Adaptive(minSize = 200.dp)) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(count = 2),
+        modifier = modifier
+    ) {
         items(agents) {
             AgentItem(
                 agent = it,
                 modifier = Modifier
-                    .clickable { onAgentClicked(it.uuid) }
+                    .clickable { onAgentClicked(it.uuid, it.displayName) }
             )
         }
     }

--- a/app/src/main/java/com/example/valorantandroid/ui/core/ValorantApp.kt
+++ b/app/src/main/java/com/example/valorantandroid/ui/core/ValorantApp.kt
@@ -1,53 +1,90 @@
 package com.example.valorantandroid.ui.core
 
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.example.valorantandroid.ValorantTopAppBar
 import com.example.valorantandroid.feature.agent.AgentDetailsScreen
 import com.example.valorantandroid.feature.agent.AgentDetailsViewModel
 import com.example.valorantandroid.feature.agent.AgentsScreen
 import com.example.valorantandroid.feature.agent.AgentsViewModel
 
+private enum class NavDestinations(
+    val screenTitle: String,
+    val destinationName: String
+) {
+    AGENTS_LIST("Agents", "agentList"),
+    AGENT_DETAILS("Agent Details", "agentList/{agentUuid}/{agentName}")
+}
+
 @Composable
 fun ValorantApp(
-    navController: NavHostController = rememberNavController()
+    navController: NavHostController = rememberNavController(),
+    modifier: Modifier = Modifier
 ) {
-    NavHost(
-        navController = navController,
-        startDestination = "agents"
-    ) {
-        agentsNavGraph(navController = navController)
+    Scaffold(
+        topBar = {
+            ValorantTopAppBar(
+                appBarTitle = getTopBarTitle(navController.currentBackStackEntryAsState()),
+                canNavigateUp = navController.previousBackStackEntry != null,
+                navigateUp = { navController.navigateUp() }
+            )
+        },
+        modifier = modifier
+    )
+    {
+        NavHost(
+            navController = navController,
+            startDestination = "agents",
+            modifier = Modifier
+                .padding(it)
+        ) {
+            agentsNavGraph(
+                navController = navController
+            )
+        }
     }
 }
 
 fun NavGraphBuilder.agentsNavGraph(navController: NavController) {
     navigation(
         route = "agents",
-        startDestination = "agentsList"
+        startDestination = "agentList",
     ) {
         composable(
-            route = "agentsList"
+            route = "agentList"
         ) {
             val viewModel = hiltViewModel<AgentsViewModel>()
             val agentsUiState by viewModel.agentsScreenUiState.collectAsState()
             AgentsScreen(
                 agentsUiState = agentsUiState,
-                onAgentClicked = { navController.navigate("agent/$it") }
+                onAgentClicked = { uuid, name ->
+                    navController.navigate("agentList/$uuid/$name")
+                }
             )
         }
         composable(
-            route = "agent/{agentUuid}",
-            arguments = listOf(navArgument("agentUuid") { type = NavType.StringType })
+            route = "agentList/{agentUuid}/{agentName}",
+            arguments = listOf(
+                navArgument("agentUuid") { type = NavType.StringType },
+                navArgument("agentName") { type = NavType.StringType },
+            )
         ) {
             val viewModel = hiltViewModel<AgentDetailsViewModel>()
             val agentDetailsUiState by viewModel.agentDetailsUiState.collectAsState()
@@ -56,4 +93,15 @@ fun NavGraphBuilder.agentsNavGraph(navController: NavController) {
             )
         }
     }
+}
+
+private fun getTopBarTitle(navBackStackEntry: State<NavBackStackEntry?>): String = when (
+    navBackStackEntry.value?.destination?.route
+) {
+    NavDestinations.AGENTS_LIST.destinationName ->
+        NavDestinations.AGENTS_LIST.screenTitle
+    NavDestinations.AGENT_DETAILS.destinationName ->
+        navBackStackEntry.value?.arguments?.getString("agentName").orEmpty()
+    else ->
+        "Destination name not handled!"
 }


### PR DESCRIPTION
**Below is a simple top app bar implementation, displaying the agent details title and the agents name when moving to the details screen. In addition the back button only comes into view when there is a previous entry in the back stack and the scaffold recomposes.**
| Agents Top App Bar | Agent Details Top App Bar |
| --- | --- |
|![agentsTopAppBar](https://github.com/jamesdpli/ValorantAndroid/assets/96268466/4f9d6440-5ca3-4aac-a6a9-fe14e1d24fb1) |![agentDetailsTopAppBar](https://github.com/jamesdpli/ValorantAndroid/assets/96268466/c5c4401e-efc2-4f3a-8d45-21fa9c122c38) | 