### PR TITLE
Add persistent favourite agents part one

### DIFF
--- a/app/src/main/java/com/example/valorantandroid/agent/data/dao/AgentDao.kt
+++ b/app/src/main/java/com/example/valorantandroid/agent/data/dao/AgentDao.kt
@@ -1,6 +1,7 @@
 package com.example.valorantandroid.agent.data.dao
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
@@ -8,9 +9,12 @@ import com.example.valorantandroid.agent.data.model.local.AgentEntity
 
 @Dao
 interface AgentDao {
-    @Query("SELECT * FROM agents")
+    @Query("SELECT * FROM favourite_agents")
     fun getAllAgents(): List<AgentEntity>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertAgent(agentEntity: AgentEntity)
+
+    @Delete
+    fun deleteAgent(agentEntity: AgentEntity)
 }

--- a/app/src/main/java/com/example/valorantandroid/agent/data/model/local/AgentEntity.kt
+++ b/app/src/main/java/com/example/valorantandroid/agent/data/model/local/AgentEntity.kt
@@ -4,7 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "agents")
+@Entity(tableName = "favourite_agents")
 data class AgentEntity(
     @PrimaryKey
     val uuid: String,

--- a/app/src/main/java/com/example/valorantandroid/agent/data/repository/AgentsRepository.kt
+++ b/app/src/main/java/com/example/valorantandroid/agent/data/repository/AgentsRepository.kt
@@ -1,20 +1,34 @@
 package com.example.valorantandroid.agent.data.repository
 
-import com.example.valorantandroid.agent.domain.mapper.toDomainModel
-import com.example.valorantandroid.agent.domain.model.AgentDomainModel
+import com.example.valorantandroid.agent.data.dao.AgentDao
+import com.example.valorantandroid.agent.data.model.local.AgentEntity
 import com.example.valorantandroid.agent.data.service.ValorantAgentService
+import com.example.valorantandroid.agent.domain.mapper.toDomainModel
+import com.example.valorantandroid.agent.domain.mapper.toEntity
+import com.example.valorantandroid.agent.domain.model.AgentDomainModel
 import javax.inject.Inject
 
 class AgentsRepository @Inject constructor(
-    private val valorantService: ValorantAgentService
+    private val valorantService: ValorantAgentService,
+    private val dao: AgentDao
 ) {
-    suspend fun getAgents(): List<AgentDomainModel> = valorantService
+    suspend fun getAgentsFromNetwork(): List<AgentDomainModel> = valorantService
         .getAgents()
         .agents
         .map { it.toDomainModel() }
 
-    suspend fun getAgentByUuid(uuid: String): AgentDomainModel = valorantService
+    suspend fun getAgentByUuidFromNetwork(uuid: String): AgentDomainModel = valorantService
         .getAgentByUuid(uuid)
         .agent
         .toDomainModel()
+
+    fun getFavouriteAgents(): List<AgentDomainModel> = dao
+        .getAllAgents()
+        .map(AgentEntity::toDomainModel)
+
+    fun insertFavouriteAgent(agentDomainModel: AgentDomainModel) = dao
+        .insertAgent(agentDomainModel.toEntity())
+
+    fun deleteFavouriteAgent(agentDomainModel: AgentDomainModel) = dao
+        .deleteAgent(agentDomainModel.toEntity())
 }

--- a/app/src/main/java/com/example/valorantandroid/agent/domain/mapper/AgentNetworkMapper.kt
+++ b/app/src/main/java/com/example/valorantandroid/agent/domain/mapper/AgentNetworkMapper.kt
@@ -1,5 +1,6 @@
 package com.example.valorantandroid.agent.domain.mapper
 
+import com.example.valorantandroid.agent.data.model.local.AgentEntity
 import com.example.valorantandroid.agent.data.model.network.AgentDetailsNetworkModel
 import com.example.valorantandroid.agent.data.model.network.AgentsNetworkModel
 import com.example.valorantandroid.agent.domain.model.AgentDomainModel
@@ -15,6 +16,21 @@ fun AgentsNetworkModel.Agent.toDomainModel() : AgentDomainModel = AgentDomainMod
 fun AgentDetailsNetworkModel.Agent.toDomainModel(): AgentDomainModel = AgentDomainModel(
     uuid = this.uuid,
     name = this.displayName,
+    description = this.description,
+    displayIcon = this.displayIcon,
+    fullPortrait = this.fullPortrait
+)
+
+fun AgentEntity.toDomainModel(): AgentDomainModel = AgentDomainModel(
+    uuid = this.uuid,
+    name = this.name,
+    description = this.description,
+    displayIcon = this.displayIcon,
+    fullPortrait = this.fullPortrait
+)
+fun AgentDomainModel.toEntity(): AgentEntity = AgentEntity(
+    uuid = this.uuid,
+    name = this.name,
     description = this.description,
     displayIcon = this.displayIcon,
     fullPortrait = this.fullPortrait

--- a/app/src/main/java/com/example/valorantandroid/agent/ui/screen/AgentsScreen.kt
+++ b/app/src/main/java/com/example/valorantandroid/agent/ui/screen/AgentsScreen.kt
@@ -7,7 +7,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Favorite
+import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -23,23 +28,28 @@ import com.example.valorantandroid.agent.ui.viewmodel.AgentsUiState
 @Composable
 fun AgentsScreen(
     agentsUiState: AgentsUiState,
+    toggleFavouriteAgent: (AgentDomainModel) -> Unit,
     onAgentClicked: (uuid: String, name: String) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    when (agentsUiState) {
-        is AgentsUiState.IsLoading -> Text(
+    when {
+        agentsUiState.isLoading -> Text(
             text = "Loading",
             modifier = modifier
                 .fillMaxSize()
         )
-        is AgentsUiState.Success -> AgentsList(
+
+        agentsUiState.isSuccess -> AgentsList(
             agents = agentsUiState.agents,
+            favouriteAgents = agentsUiState.favouriteAgents,
+            toggleFavouriteAgent = toggleFavouriteAgent,
             onAgentClicked = onAgentClicked,
             modifier = modifier
                 .fillMaxSize()
         )
-        is AgentsUiState.IsError -> Text(
-            text = agentsUiState.message,
+
+        !agentsUiState.errorMessage.isNullOrEmpty() -> Text(
+            text = agentsUiState.errorMessage,
             modifier
                 .fillMaxSize()
         )
@@ -49,6 +59,8 @@ fun AgentsScreen(
 @Composable
 fun AgentsList(
     agents: List<AgentDomainModel>,
+    favouriteAgents: List<AgentDomainModel>,
+    toggleFavouriteAgent: (AgentDomainModel) -> Unit,
     onAgentClicked: (uuid: String, name: String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -59,6 +71,8 @@ fun AgentsList(
         items(agents) {
             AgentItem(
                 agent = it,
+                favourites = favouriteAgents,
+                toggleFavouriteAgent = toggleFavouriteAgent,
                 modifier = Modifier
                     .clickable { onAgentClicked(it.uuid, it.name) }
             )
@@ -69,6 +83,8 @@ fun AgentsList(
 @Composable
 fun AgentItem(
     agent: AgentDomainModel,
+    favourites: List<AgentDomainModel>,
+    toggleFavouriteAgent: (AgentDomainModel) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(
@@ -76,6 +92,13 @@ fun AgentItem(
             .fillMaxWidth()
             .padding(5.dp)
     ) {
+        IconButton(onClick = { toggleFavouriteAgent(agent) }) {
+            if (favourites.map { it.uuid }.contains(agent.uuid)) {
+                Icon(imageVector = Icons.Outlined.Favorite, contentDescription = "")
+            } else {
+                Icon(imageVector = Icons.Outlined.FavoriteBorder, contentDescription ="")
+            }
+        }
         AsyncImage(
             model = agent.displayIcon,
             contentDescription = agent.name + "portrait",

--- a/app/src/main/java/com/example/valorantandroid/agent/ui/viewmodel/AgentDetailsViewModel.kt
+++ b/app/src/main/java/com/example/valorantandroid/agent/ui/viewmodel/AgentDetailsViewModel.kt
@@ -36,7 +36,7 @@ class AgentDetailsViewModel @Inject constructor(
     fun getAgentDetails(uuid: String) = viewModelScope.launch {
         try {
             _agentDetailsUiState.value =
-                AgentDetailsUiState.Success(repository.getAgentByUuid(uuid))
+                AgentDetailsUiState.Success(repository.getAgentByUuidFromNetwork(uuid))
         } catch (e: IOException) {
             _agentDetailsUiState.value = AgentDetailsUiState.Error
         }

--- a/app/src/main/java/com/example/valorantandroid/core/data/di/DatabaseModule.kt
+++ b/app/src/main/java/com/example/valorantandroid/core/data/di/DatabaseModule.kt
@@ -2,8 +2,8 @@ package com.example.valorantandroid.core.data.di
 
 import android.app.Application
 import androidx.room.Room
-import com.example.valorantandroid.core.data.database.ValorantAppDatabase
 import com.example.valorantandroid.agent.data.dao.AgentDao
+import com.example.valorantandroid.core.data.database.ValorantAppDatabase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/app/src/main/java/com/example/valorantandroid/core/navigation/ValorantApp.kt
+++ b/app/src/main/java/com/example/valorantandroid/core/navigation/ValorantApp.kt
@@ -70,6 +70,9 @@ fun NavGraphBuilder.agentsNavGraph(navController: NavController) {
             val agentsUiState by viewModel.agentsScreenUiState.collectAsState()
             AgentsScreen(
                 agentsUiState = agentsUiState,
+                toggleFavouriteAgent = {
+                    viewModel.toggleFavouriteAgent(it)
+                },
                 onAgentClicked = { uuid, name ->
                     navController.navigate("agentList/$uuid/$name")
                 }


### PR DESCRIPTION
1) Agents can now be favourited and this information is persisted to a Room Database.

<img width="1440" alt="Screenshot 2024-01-04 at 16 47 25" src="https://github.com/jamesdpli/ValorantAndroid/assets/96268466/7bd8090b-0757-4e6d-b596-6c32a99dc41e">

2) `app/src/main/java/com/example/valorantandroid/agent/ui/viewmodel/AgentsViewModel.kt` AgentUiState sealed interface has been swapped out for a data class and in a future PR will be moved back to a sealed interface similar to one described here: https://medium.com/bumble-tech/crash-course-on-the-android-ui-layer-part-1-2094221a9be3
